### PR TITLE
load more button above the legend works! a number of bugs remain

### DIFF
--- a/church_fathers.json
+++ b/church_fathers.json
@@ -402,6 +402,22 @@
     "percentage": 33,
     "year": 325
   },
+ {
+    "title": "minuscule 720",
+    "description": "",
+    "texts": [
+      "Theophylact Commentary on Gospels",
+      "Pauline Epistles",
+      "General Epistles"
+    ],
+    "family": "",
+    "location": "",
+    "y": "15",
+    "eventType": "Minuscule",
+    "percentage": 114,
+    "year": 1138
+  },
+  
   {
     "title": "The Writings of Eusebius of Caesarea",
     "description": "Although he lived into the post-Nicene period, his early works like Ecclesiastical History and Chronicon are key sources for Ante-Nicene history. Manuscript:",

--- a/church_fathers.json
+++ b/church_fathers.json
@@ -417,7 +417,19 @@
     "percentage": 114,
     "year": 1138
   },
-  
+   {
+    "title": "ℓ 1043",
+    "description": "",
+    "texts": [
+      "Gospels"
+    ],
+    "family": "",
+    "location": "",
+    "y": "15",
+    "eventType": "lectionary",
+    "percentage": 45,
+    "year": 450
+  },
   {
     "title": "The Writings of Eusebius of Caesarea",
     "description": "Although he lived into the post-Nicene period, his early works like Ecclesiastical History and Chronicon are key sources for Ante-Nicene history. Manuscript:",

--- a/index.html
+++ b/index.html
@@ -49,9 +49,11 @@
 
             <!-- Legend Items -->
             <div class="legend-item">
-                <input type="checkbox" class="legend-checkbox" id="minuscules-checkbox" checked>
-                <span>Minuscules Events</span>
-            </div>
+    <input type="checkbox" class="legend-checkbox" id="minuscules-checkbox" checked>
+    <span>Minuscules Events</span>
+    <button id="load-more-minuscules" class="load-more-btn">Load More Manuscripts</button>
+</div>
+
 
             <div class="legend-item">
                 <input type="checkbox" class="legend-checkbox" id="lectionaries-checkbox" checked>

--- a/index.html
+++ b/index.html
@@ -51,13 +51,11 @@
             <div class="legend-item">
                 <input type="checkbox" class="legend-checkbox" id="minuscules-checkbox" checked>
                 <span>Minuscules Events</span>
-                <button id="load-more-minuscules" class="load-more-btn">Load More</button>
             </div>
 
             <div class="legend-item">
                 <input type="checkbox" class="legend-checkbox" id="lectionaries-checkbox" checked>
                 <span>Lectionaries Events</span>
-                <button id="load-more-lectionaries" class="load-more-btn">Load More</button>
             </div>
 
             <!-- Load More Button for Event Types -->

--- a/index.html
+++ b/index.html
@@ -51,18 +51,21 @@
             <div class="legend-item">
                 <input type="checkbox" class="legend-checkbox" id="minuscules-checkbox" checked>
                 <span>Minuscules Events</span>
+                <button id="load-more-minuscules" class="load-more-btn">Load More</button>
             </div>
 
             <div class="legend-item">
                 <input type="checkbox" class="legend-checkbox" id="lectionaries-checkbox" checked>
                 <span>Lectionaries Events</span>
+                <button id="load-more-lectionaries" class="load-more-btn">Load More</button>
             </div>
 
-            <!-- Load More Button Section -->
+            <!-- Load More Button for Event Types -->
             <div class="load-more-section">
-                <button id="load-more-all" class="load-more-btn">Load More Events</button>
+                <button id="load-more-event-types" class="load-more-btn">Load More Events</button>
             </div>
         </div>
+        
         <div class="sidebar-section">
             <h3>Texts <span class="question-mark">?
                 <span class="tooltip">Filter events by specific texts.</span>

--- a/index.html
+++ b/index.html
@@ -40,6 +40,10 @@
         <div class="timeline-controls">
             <button id="zoom-in">+</button>
             <button id="zoom-out">-</button>
+            <!-- Move Load More Button Here -->
+            <div class="load-more-section">
+                <button id="load-more-event-types" class="load-more-btn">Load More Events</button>
+            </div>
         </div>
         <div class="sidebar-section" id="legend">
             <h3>Legend</h3>
@@ -49,20 +53,15 @@
 
             <!-- Legend Items -->
             <div class="legend-item">
-    <input type="checkbox" class="legend-checkbox" id="minuscules-checkbox" checked>
-    <span>Minuscules Events</span>
-    <button id="load-more-minuscules" class="load-more-btn">Load More Manuscripts</button>
-</div>
-
+                <input type="checkbox" class="legend-checkbox" id="minuscules-checkbox" checked>
+                <span>Minuscules Events</span>
+                <button id="load-more-minuscules" class="load-more-btn">Load More</button>
+            </div>
 
             <div class="legend-item">
                 <input type="checkbox" class="legend-checkbox" id="lectionaries-checkbox" checked>
                 <span>Lectionaries Events</span>
-            </div>
-
-            <!-- Load More Button for Event Types -->
-            <div class="load-more-section">
-                <button id="load-more-event-types" class="load-more-btn">Load More Events</button>
+                <button id="load-more-lectionaries" class="load-more-btn">Load More</button>
             </div>
         </div>
         

--- a/index.html
+++ b/index.html
@@ -41,12 +41,13 @@
             <button id="zoom-in">+</button>
             <button id="zoom-out">-</button>
         </div>
-        <div class="sidebar-section" id="legend">
-            <h3>Legend</h3>
-            <button id="toggle-legend" aria-label="Toggle legend" class="toggle-legend">
-                <div class="arrow"></div>
-            </button>
-        </div>
+       <div class="sidebar-section" id="legend">
+    <h3>Legend</h3>
+    <button id="toggle-legend" aria-label="Toggle legend" class="toggle-legend">
+        <div class="arrow"></div>
+    </button>
+    <!-- The legend items will be dynamically added here -->
+</div>
         <div class="sidebar-section">
             <h3>Texts <span class="question-mark">?
                 <span class="tooltip">Filter events by specific texts.</span>

--- a/index.html
+++ b/index.html
@@ -41,13 +41,27 @@
             <button id="zoom-in">+</button>
             <button id="zoom-out">-</button>
         </div>
-       <div class="sidebar-section" id="legend">
-    <h3>Legend</h3>
-    <button id="toggle-legend" aria-label="Toggle legend" class="toggle-legend">
-        <div class="arrow"></div>
-    </button>
-    <!-- The legend items will be dynamically added here -->
-</div>
+        <div class="sidebar-section" id="legend">
+            <h3>Legend</h3>
+            <button id="toggle-legend" aria-label="Toggle legend" class="toggle-legend">
+                <div class="arrow"></div>
+            </button>
+
+            <!-- Legend Items with Load More Buttons -->
+            <div class="legend-item">
+                <input type="checkbox" class="legend-checkbox" id="minuscules-checkbox" checked>
+                <span>Minuscules Events</span>
+                <button id="load-more-minuscules" class="load-more-btn">Load More</button>
+            </div>
+
+            <div class="legend-item">
+                <input type="checkbox" class="legend-checkbox" id="lectionaries-checkbox" checked>
+                <span>Lectionaries Events</span>
+                <button id="load-more-lectionaries" class="load-more-btn">Load More</button>
+            </div>
+
+            <!-- Additional legend items can be added here -->
+        </div>
         <div class="sidebar-section">
             <h3>Texts <span class="question-mark">?
                 <span class="tooltip">Filter events by specific texts.</span>

--- a/index.html
+++ b/index.html
@@ -58,8 +58,10 @@
                 <span>Lectionaries Events</span>
             </div>
 
-            <!-- Single Load More Button -->
-            <button id="load-more-all" class="load-more-btn">Load More Events</button>
+            <!-- Load More Button Section -->
+            <div class="load-more-section">
+                <button id="load-more-all" class="load-more-btn">Load More Events</button>
+            </div>
         </div>
         <div class="sidebar-section">
             <h3>Texts <span class="question-mark">?

--- a/index.html
+++ b/index.html
@@ -47,20 +47,19 @@
                 <div class="arrow"></div>
             </button>
 
-            <!-- Legend Items with Load More Buttons -->
+            <!-- Legend Items -->
             <div class="legend-item">
                 <input type="checkbox" class="legend-checkbox" id="minuscules-checkbox" checked>
                 <span>Minuscules Events</span>
-                <button id="load-more-minuscules" class="load-more-btn">Load More</button>
             </div>
 
             <div class="legend-item">
                 <input type="checkbox" class="legend-checkbox" id="lectionaries-checkbox" checked>
                 <span>Lectionaries Events</span>
-                <button id="load-more-lectionaries" class="load-more-btn">Load More</button>
             </div>
 
-            <!-- Additional legend items can be added here -->
+            <!-- Single Load More Button -->
+            <button id="load-more-all" class="load-more-btn">Load More Events</button>
         </div>
         <div class="sidebar-section">
             <h3>Texts <span class="question-mark">?

--- a/scripts.js
+++ b/scripts.js
@@ -8,10 +8,6 @@ let selectedEvent = null;
 const texts = new Set();
 const families = new Set();
 const eventTypes = new Set();
-const dotDiameter = 12;
-const spacing = 15;
-const step = 5;
-
 const eventTypeColors = {};
 
 document.getElementById('toggle-legend').addEventListener('click', () => {
@@ -45,7 +41,6 @@ async function loadEvents() {
         populateTextList();
         populateFamilyList();
         generateLegend();
-
     } catch (error) {
         console.error('Error loading events:', error);
     }
@@ -69,7 +64,7 @@ document.getElementById('load-more-all').addEventListener('click', async () => {
         populateFamilyList(); // Repopulate family list
         generateLegend(); // Refresh legend to include new event types with colors
 
-        // Hide the button after loading
+        // Hide the button after loading if desired
         document.getElementById('load-more-all').style.display = 'none';
     } catch (error) {
         console.error('Error loading more events:', error);
@@ -308,8 +303,7 @@ function generateLegend() {
         const checkbox = document.createElement('input');
         checkbox.type = 'checkbox';
         checkbox.className = 'legend-checkbox';
-        // Uncheck the uncial and minuscule filters by default
-        checkbox.checked = !(eventType === 'lectionary' || eventType === 'Minuscule');
+        checkbox.checked = true;
         checkbox.addEventListener('change', (e) => {
             toggleEventsByType(eventType, e.target.checked);
         });

--- a/scripts.js
+++ b/scripts.js
@@ -47,7 +47,7 @@ async function loadEvents() {
         initializeFilters();
         populateTextList();
         populateFamilyList();
-        generateLegend();
+        generateLegend();  // Make sure this is called to create legend items
 
     } catch (error) {
         console.error('Error loading events:', error);

--- a/scripts.js
+++ b/scripts.js
@@ -12,15 +12,9 @@ const dotDiameter = 12;
 const spacing = 15;
 const step = 5;
 
-const eventTypeColors = {
-    'Historical': '#3498db',
-    'Manuscript': '#2ecc71',
-    'Uncial': '#e74c3c',
-    'ChurchFather': '#9b59b6',
-    'Minuscule': '#f1c40f',
-    'Lectionary': '#e67e22'
-};
+const eventTypeColors = {};
 
+// Event listener for the legend toggle button
 document.getElementById('toggle-legend').addEventListener('click', () => {
     const legend = document.getElementById('legend');
     legend.classList.toggle('collapsed');
@@ -28,12 +22,14 @@ document.getElementById('toggle-legend').addEventListener('click', () => {
     arrow.classList.toggle('collapsed');
 });
 
+// Event listener for the sidebar toggle button
 document.getElementById('toggle-sidebar').addEventListener('click', () => {
     sidebar.classList.toggle('collapsed');
     const arrow = document.querySelector('#toggle-sidebar .arrow-reverse');
     arrow.classList.toggle('collapsed');
 });
 
+// Function to load initial events
 async function loadEvents() {
     try {
         // Fetch and process initial events
@@ -53,7 +49,6 @@ async function loadEvents() {
         populateFamilyList();
         generateLegend();
 
-        // Defer loading additional events (remove setTimeout)
     } catch (error) {
         console.error('Error loading events:', error);
     }
@@ -81,7 +76,24 @@ async function loadDeferredEvents() {
     }
 }
 
+// Function to process and add events to the timeline
+function processEvents(...eventGroups) {
+    eventGroups.forEach(events => {
+        events.forEach(event => {
+            processEvent(event);
+            addEventToTimeline(event);
+            if (event.texts) {
+                event.texts.forEach(text => texts.add(text));
+            }
+            if (event.family) {
+                families.add(event.family);
+            }
+            eventTypes.add(event.eventType);
+        });
+    });
+}
 
+// Function to populate text filters
 function populateTextList() {
     const textList = document.getElementById('text-list');
     textList.innerHTML = '';
@@ -95,6 +107,7 @@ function populateTextList() {
     });
 }
 
+// Function to populate family filters
 function populateFamilyList() {
     const familyList = document.getElementById('family-list');
     familyList.innerHTML = '';
@@ -108,28 +121,25 @@ function populateFamilyList() {
     });
 }
 
-function addYearLabels() {
-    const yearLabels = [
-        { year: 0, left: '0%' },
-        { year: 100, left: '7%' },
-        { year: 150, left: '11%' },
-        { year: 300, left: '22%' },
-        { year: 500, left: '32%' },
-        { year: 750, left: '53%' },
-        { year: 1000, left: '71%' },
-        { year: 1250, left: '90%' },
-        { year: 1400, left: '100%' }
-    ];
+// Function to generate colors for event types
+function generateColorsForEventTypes() {
+    eventTypes.forEach(eventType => {
+        if (!eventTypeColors[eventType]) {
+            eventTypeColors[eventType] = `#${Math.floor(Math.random() * 16777215).toString(16)}`;
+        }
+    });
 
-    yearLabels.forEach(label => {
-        const yearLabel = document.createElement('div');
-        yearLabel.className = 'year-label';
-        yearLabel.style.left = label.left;
-        yearLabel.innerText = label.year;
-        timeline.appendChild(yearLabel);
+    // Update colors for existing events
+    const events = document.querySelectorAll('.event');
+    events.forEach(event => {
+        const eventType = event.getAttribute('data-event-type');
+        if (eventTypeColors[eventType]) {
+            event.style.backgroundColor = eventTypeColors[eventType];
+        }
     });
 }
 
+// Function to process individual event
 function processEvent(event) {
     if (event.year) {
         event.percentage = (event.year / 1400) * 100;
@@ -143,6 +153,7 @@ function processEvent(event) {
     console.log('Processed Event:', event);
 }
 
+// Function to add an event to the timeline
 function addEventToTimeline(event) {
     console.log('Adding event to timeline:', event);
     if (document.querySelector(`.event[title="${event.title}"]`)) {
@@ -174,6 +185,7 @@ function addEventToTimeline(event) {
     });
 }
 
+// Function to update event interactions
 function updateEvents() {
     const events = document.querySelectorAll('.event');
     events.forEach(event => {
@@ -199,65 +211,7 @@ function updateEvents() {
     });
 }
 
-function populateTextList() {
-    const textList = document.getElementById('text-list');
-    textList.innerHTML = '';
-    texts.forEach(text => {
-        const listItem = document.createElement('li');
-        listItem.innerHTML = `<input type="checkbox" checked> ${text}`;
-        listItem.querySelector('input').addEventListener('change', (e) => {
-            filterEventsByText(text, e.target.checked);
-        });
-        textList.appendChild(listItem);
-    });
-}
-
-function populateFamilyList() {
-    const familyList = document.getElementById('family-list');
-    familyList.innerHTML = '';
-    families.forEach(family => {
-        const listItem = document.createElement('li');
-        listItem.innerHTML = `<input type="checkbox" checked> ${family}`;
-        listItem.querySelector('input').addEventListener('change', (e) => {
-            filterEventsByFamily(family, e.target.checked);
-        });
-        familyList.appendChild(listItem);
-    });
-}
-
-function filterEventsByText(text, isChecked) {
-    const events = document.querySelectorAll('.event');
-    events.forEach(event => {
-        const eventTexts = JSON.parse(event.getAttribute('data-texts'));
-        if (isChecked && eventTexts.includes(text)) {
-            event.classList.remove('greyed-out');
-        } else if (!isChecked && eventTexts.includes(text)) {
-            event.classList.add('greyed-out');
-        }
-    });
-}
-
-function filterEventsByFamily(family, isChecked) {
-    const events = document.querySelectorAll('.event');
-    events.forEach(event => {
-        const eventFamily = event.getAttribute('data-family');
-        if (isChecked && eventFamily === family) {
-            event.classList.remove('greyed-out');
-        } else if (!isChecked && eventFamily === family) {
-            event.classList.add('greyed-out');
-        }
-    });
-}
-
-const css = `
-    .greyed-out {
-        display: none;
-    }
-`;
-const style = document.createElement('style');
-style.appendChild(document.createTextNode(css));
-document.head.appendChild(style);
-
+// Initialize filters
 function initializeFilters() {
     const textList = document.getElementById('text-list');
     const familyList = document.getElementById('family-list');
@@ -281,10 +235,12 @@ function initializeFilters() {
     });
 }
 
+// Function to get color for an event type
 function getColorForEventType(eventType) {
     return eventTypeColors[eventType];
 }
 
+// Function to generate the legend
 function generateLegend() {
     legendContainer.innerHTML = '';
 
@@ -337,8 +293,7 @@ function generateLegend() {
     });
 }
 
-
-
+// Function to toggle events by type
 function toggleEventsByType(eventType, isChecked) {
     const events = document.querySelectorAll(`.event[data-event-type="${eventType}"]`);
     events.forEach(event => {
@@ -346,10 +301,91 @@ function toggleEventsByType(eventType, isChecked) {
     });
 }
 
+// Function to filter events by text
+function filterEventsByText(text, isChecked) {
+    const events = document.querySelectorAll('.event');
+    events.forEach(event => {
+        const eventTexts = JSON.parse(event.getAttribute('data-texts'));
+        if (isChecked && eventTexts.includes(text)) {
+            event.classList.remove('greyed-out');
+        } else if (!isChecked && eventTexts.includes(text)) {
+            event.classList.add('greyed-out');
+        }
+    });
+}
+
+// Function to filter events by family
+function filterEventsByFamily(family, isChecked) {
+    const events = document.querySelectorAll('.event');
+    events.forEach(event => {
+        const eventFamily = event.getAttribute('data-family');
+        if (isChecked && eventFamily === family) {
+            event.classList.remove('greyed-out');
+        } else if (!isChecked && eventFamily === family) {
+            event.classList.add('greyed-out');
+        }
+    });
+}
+
+// Additional CSS for greyed-out events
+const css = `
+    .greyed-out {
+        display: none;
+    }
+`;
+const style = document.createElement('style');
+style.appendChild(document.createTextNode(css));
+document.head.appendChild(style);
+
+// Function to add year labels
+function addYearLabels() {
+    const yearLabels = [
+        { year: 0, left: '0%' },
+        { year: 100, left: '7%' },
+        { year: 150, left: '11%' },
+        { year: 300, left: '22%' },
+        { year: 500, left: '32%' },
+        { year: 750, left: '53%' },
+        { year: 1000, left: '71%' },
+        { year: 1250, left: '90%' },
+        { year: 1400, left: '100%' }
+    ];
+
+    yearLabels.forEach(label => {
+        const yearLabel = document.createElement('div');
+        yearLabel.className = 'year-label';
+        yearLabel.style.left = label.left;
+        yearLabel.innerText = label.year;
+        timeline.appendChild(yearLabel);
+    });
+}
+
+// Function to set up the progress bar
+function setUpProgressBar() {
+    const header = document.querySelector('header');
+    const progressBar = document.createElement('div');
+    progressBar.id = 'progress-bar';
+    header.appendChild(progressBar);
+
+    let progress = 0;
+    const interval = setInterval(() => {
+        if (progress < 100) {
+            progress += 5;
+            progressBar.style.width = `${progress}%`;
+        } else {
+            clearInterval(interval);
+            // Hide the progress bar after loading is complete
+            setTimeout(() => progressBar.style.display = 'none', 500);
+        }
+    }, 100); // Adjust timing as necessary
+}
+
+// Function to toggle the sidebar
 function toggleSidebar() {
     sidebar.classList.toggle('collapsed');
 }
 
+// Zoom in and out functionality
 document.getElementById('zoom-in').addEventListener('click', () => {
     scale *= 1.2;
     timeline.style.transform = `scale(${scale})`;
@@ -360,6 +396,7 @@ document.getElementById('zoom-out').addEventListener('click', () => {
     timeline.style.transform = `scale(${scale})`;
 });
 
+// Scroll and drag functionality for the timeline
 timelineContainer.addEventListener('dblclick', (e) => {
     const rect = timelineContainer.getBoundingClientRect();
     const offsetX = e.clientX - rect.left;
@@ -401,10 +438,13 @@ timelineContainer.addEventListener('mousemove', (e) => {
     timelineContainer.scrollLeft = scrollLeft - walk;
 });
 
+// Resize observer for timeline
 new ResizeObserver(() => {
     timelineContainer.scrollLeft = (timeline.scrollWidth - timelineContainer.clientWidth) / 2;
 }).observe(timelineContainer);
 
+// Event listener for document ready
 document.addEventListener('DOMContentLoaded', function() {
+    setUpProgressBar();
     loadEvents();
 });

--- a/scripts.js
+++ b/scripts.js
@@ -280,7 +280,6 @@ function generateLegend() {
         legendItem.appendChild(label);
         legendItem.appendChild(questionMark);
 
-        // Add Load More button for deferred event types
         if (eventType === 'minuscules' || eventType === 'lectionaries') {
             const loadMoreButton = document.createElement('button');
             loadMoreButton.textContent = 'Load More';
@@ -351,6 +350,10 @@ const css = `
         padding: 5px 10px;
         cursor: pointer;
         border-radius: 5px;
+        transition: background-color 0.3s;
+    }
+    .load-more-btn:hover {
+        background-color: #2980b9;
     }
     .load-more-btn:disabled {
         background-color: #aaa;

--- a/scripts.js
+++ b/scripts.js
@@ -54,14 +54,18 @@ async function loadEvents() {
     }
 }
 
-// New function to load deferred event types when filters are checked
-async function loadDeferredEvents() {
+// New function to load deferred event types when "Load More" is clicked
+async function loadDeferredEvents(eventType) {
     try {
-        const lectionariesEvents = await fetch('lectionaries.json').then(response => response.json());
-        const minusculesEvents = await fetch('minuscules.json').then(response => response.json());
+        let eventsToLoad;
+        if (eventType === 'lectionaries') {
+            eventsToLoad = await fetch('lectionaries.json').then(response => response.json());
+        } else if (eventType === 'minuscules') {
+            eventsToLoad = await fetch('minuscules.json').then(response => response.json());
+        }
 
         // Process deferred events
-        processEvents(lectionariesEvents, minusculesEvents);
+        processEvents(eventsToLoad);
 
         // Generate colors for any new event types that were loaded later
         generateColorsForEventTypes();
@@ -255,14 +259,9 @@ function generateLegend() {
         const checkbox = document.createElement('input');
         checkbox.type = 'checkbox';
         checkbox.className = 'legend-checkbox';
-        
-        // Uncheck the "minuscules" and "lectionaries" filters by default
-        checkbox.checked = !(eventType === 'minuscules' || eventType === 'lectionaries');
+        checkbox.checked = true; // Initially check all filters
 
-        checkbox.addEventListener('change', async (e) => {
-            if ((eventType === 'minuscules' || eventType === 'lectionaries') && e.target.checked) {
-                await loadDeferredEvents();
-            }
+        checkbox.addEventListener('change', (e) => {
             toggleEventsByType(eventType, e.target.checked);
         });
 
@@ -280,6 +279,17 @@ function generateLegend() {
         legendItem.appendChild(legendColor);
         legendItem.appendChild(label);
         legendItem.appendChild(questionMark);
+
+        if (eventType === 'minuscules' || eventType === 'lectionaries') {
+            const loadMoreButton = document.createElement('button');
+            loadMoreButton.textContent = 'Load More';
+            loadMoreButton.className = 'load-more-btn';
+            loadMoreButton.addEventListener('click', async () => {
+                await loadDeferredEvents(eventType);
+                loadMoreButton.disabled = true; // Disable button after loading
+            });
+            legendItem.appendChild(loadMoreButton);
+        }
 
         legendContainer.appendChild(legendItem);
     });
@@ -331,6 +341,19 @@ function filterEventsByFamily(family, isChecked) {
 const css = `
     .greyed-out {
         display: none;
+    }
+    .load-more-btn {
+        margin-left: 10px;
+        background-color: #3498db;
+        color: #fff;
+        border: none;
+        padding: 5px 10px;
+        cursor: pointer;
+        border-radius: 5px;
+    }
+    .load-more-btn:disabled {
+        background-color: #aaa;
+        cursor: not-allowed;
     }
 `;
 const style = document.createElement('style');

--- a/scripts.js
+++ b/scripts.js
@@ -129,6 +129,14 @@ function generateColorsForEventTypes() {
     });
 }
 
+// Define the missing function getColorForEventType
+function getColorForEventType(eventType) {
+    if (!eventTypeColors[eventType]) {
+        eventTypeColors[eventType] = `#${Math.floor(Math.random() * 16777215).toString(16)}`;
+    }
+    return eventTypeColors[eventType];
+}
+
 function addYearLabels() {
     const yearLabels = [
         { year: 0, left: '0%' },

--- a/scripts.js
+++ b/scripts.js
@@ -14,6 +14,7 @@ const step = 5;
 
 const eventTypeColors = {};
 
+// Toggle legend visibility
 document.getElementById('toggle-legend').addEventListener('click', () => {
     const legend = document.getElementById('legend');
     legend.classList.toggle('collapsed');
@@ -21,12 +22,19 @@ document.getElementById('toggle-legend').addEventListener('click', () => {
     arrow.classList.toggle('collapsed');
 });
 
+// Toggle sidebar visibility
 document.getElementById('toggle-sidebar').addEventListener('click', () => {
     sidebar.classList.toggle('collapsed');
     const arrow = document.querySelector('#toggle-sidebar .arrow-reverse');
     arrow.classList.toggle('collapsed');
 });
 
+// Load initial events when the document is ready
+document.addEventListener('DOMContentLoaded', function() {
+    loadInitialEvents();
+});
+
+// Load initial events from JSON files
 async function loadInitialEvents() {
     try {
         // Fetch and process initial events
@@ -46,30 +54,33 @@ async function loadInitialEvents() {
         populateFamilyList();
         generateLegend();
     } catch (error) {
-        console.error('Error loading initial events:', error);
+        console.error('Error loading events:', error);
     }
 }
 
-async function loadMoreEvents() {
+// Handle the "Load More Events" button click
+document.getElementById('load-more-event-types').addEventListener('click', async () => {
     try {
-        // Fetch additional events
         const lectionariesEvents = await fetch('lectionaries.json').then(response => response.json());
         const minusculesEvents = await fetch('minuscules.json').then(response => response.json());
 
         // Process additional events
         processEvents(lectionariesEvents, minusculesEvents);
 
-        // Update the timeline with new events and colors
+        // Generate colors for any new event types that were loaded later
         generateColorsForEventTypes();
+
+        // Update the timeline with new events and colors
         updateEvents();
         populateTextList(); // Repopulate text list
         populateFamilyList(); // Repopulate family list
         generateLegend(); // Refresh legend to include new event types with colors
     } catch (error) {
-        console.error('Error loading more events:', error);
+        console.error('Error loading additional events:', error);
     }
-}
+});
 
+// Process and add events to the timeline
 function processEvents(...eventGroups) {
     eventGroups.forEach(events => {
         events.forEach(event => {
@@ -86,6 +97,7 @@ function processEvents(...eventGroups) {
     });
 }
 
+// Populate the text filter list
 function populateTextList() {
     const textList = document.getElementById('text-list');
     textList.innerHTML = '';
@@ -99,6 +111,7 @@ function populateTextList() {
     });
 }
 
+// Populate the family filter list
 function populateFamilyList() {
     const familyList = document.getElementById('family-list');
     familyList.innerHTML = '';
@@ -112,6 +125,7 @@ function populateFamilyList() {
     });
 }
 
+// Generate random colors for each event type
 function generateColorsForEventTypes() {
     eventTypes.forEach(eventType => {
         if (!eventTypeColors[eventType]) {
@@ -129,14 +143,7 @@ function generateColorsForEventTypes() {
     });
 }
 
-// Define the missing function getColorForEventType
-function getColorForEventType(eventType) {
-    if (!eventTypeColors[eventType]) {
-        eventTypeColors[eventType] = `#${Math.floor(Math.random() * 16777215).toString(16)}`;
-    }
-    return eventTypeColors[eventType];
-}
-
+// Add year labels to the timeline
 function addYearLabels() {
     const yearLabels = [
         { year: 0, left: '0%' },
@@ -159,6 +166,7 @@ function addYearLabels() {
     });
 }
 
+// Process an individual event
 function processEvent(event) {
     if (event.year) {
         event.percentage = (event.year / 1400) * 100;
@@ -172,6 +180,7 @@ function processEvent(event) {
     console.log('Processed Event:', event);
 }
 
+// Add an event to the timeline
 function addEventToTimeline(event) {
     console.log('Adding event to timeline:', event);
     if (document.querySelector(`.event[title="${event.title}"]`)) {
@@ -203,6 +212,7 @@ function addEventToTimeline(event) {
     });
 }
 
+// Update event listeners for each event
 function updateEvents() {
     const events = document.querySelectorAll('.event');
     events.forEach(event => {
@@ -228,6 +238,7 @@ function updateEvents() {
     });
 }
 
+// Filter events based on selected texts
 function filterEventsByText(text, isChecked) {
     const events = document.querySelectorAll('.event');
     events.forEach(event => {
@@ -240,6 +251,7 @@ function filterEventsByText(text, isChecked) {
     });
 }
 
+// Filter events based on selected family
 function filterEventsByFamily(family, isChecked) {
     const events = document.querySelectorAll('.event');
     events.forEach(event => {
@@ -252,15 +264,7 @@ function filterEventsByFamily(family, isChecked) {
     });
 }
 
-const css = `
-    .greyed-out {
-        display: none;
-    }
-`;
-const style = document.createElement('style');
-style.appendChild(document.createTextNode(css));
-document.head.appendChild(style);
-
+// Initialize filters for text and family lists
 function initializeFilters() {
     const textList = document.getElementById('text-list');
     const familyList = document.getElementById('family-list');
@@ -284,6 +288,21 @@ function initializeFilters() {
     });
 }
 
+// Generate colors for each event type
+function generateColorsForEventTypes() {
+    eventTypes.forEach(eventType => {
+        if (!eventTypeColors[eventType]) {
+            eventTypeColors[eventType] = `#${Math.floor(Math.random() * 16777215).toString(16)}`;
+        }
+    });
+}
+
+// Get color for a specific event type
+function getColorForEventType(eventType) {
+    return eventTypeColors[eventType];
+}
+
+// Generate legend items for event types
 function generateLegend() {
     legendContainer.innerHTML = '';
 
@@ -298,7 +317,6 @@ function generateLegend() {
         const checkbox = document.createElement('input');
         checkbox.type = 'checkbox';
         checkbox.className = 'legend-checkbox';
-        // Uncheck the uncial and minuscule filters by default
         checkbox.checked = !(eventType === 'lectionary' || eventType === 'Minuscule');
         checkbox.addEventListener('change', (e) => {
             toggleEventsByType(eventType, e.target.checked);
@@ -331,6 +349,7 @@ function generateLegend() {
     });
 }
 
+// Toggle events visibility by type
 function toggleEventsByType(eventType, isChecked) {
     const events = document.querySelectorAll(`.event[data-event-type="${eventType}"]`);
     events.forEach(event => {
@@ -338,10 +357,12 @@ function toggleEventsByType(eventType, isChecked) {
     });
 }
 
+// Toggle sidebar visibility
 function toggleSidebar() {
     sidebar.classList.toggle('collapsed');
 }
 
+// Zoom controls
 document.getElementById('zoom-in').addEventListener('click', () => {
     scale *= 1.2;
     timeline.style.transform = `scale(${scale})`;
@@ -352,6 +373,7 @@ document.getElementById('zoom-out').addEventListener('click', () => {
     timeline.style.transform = `scale(${scale})`;
 });
 
+// Double-click to center timeline
 timelineContainer.addEventListener('dblclick', (e) => {
     const rect = timelineContainer.getBoundingClientRect();
     const offsetX = e.clientX - rect.left;
@@ -367,6 +389,7 @@ timelineContainer.addEventListener('dblclick', (e) => {
     timeline.style.transform = `scale(${scale})`;
 });
 
+// Timeline drag controls
 let isDown = false;
 let startX;
 let scrollLeft;
@@ -393,12 +416,7 @@ timelineContainer.addEventListener('mousemove', (e) => {
     timelineContainer.scrollLeft = scrollLeft - walk;
 });
 
+// Center timeline on window resize
 new ResizeObserver(() => {
     timelineContainer.scrollLeft = (timeline.scrollWidth - timelineContainer.clientWidth) / 2;
 }).observe(timelineContainer);
-
-document.addEventListener('DOMContentLoaded', function() {
-    loadInitialEvents();
-    // Add an event listener to load more events when the button is clicked
-    document.getElementById('load-more-event-types').addEventListener('click', loadMoreEvents);
-});

--- a/scripts.js
+++ b/scripts.js
@@ -309,7 +309,7 @@ function generateLegend() {
         questionMark.textContent = '?';
         const tooltip = document.createElement('span');
         tooltip.className = 'tooltip';
-        tooltip.textContent = `Filter events by ${eventType} type`;
+        tooltip.textContent = `Filter events by ${eventType} type!`;
         questionMark.appendChild(tooltip);
         legendItem.appendChild(checkbox);
         legendItem.appendChild(legendColor);

--- a/scripts.js
+++ b/scripts.js
@@ -8,6 +8,10 @@ let selectedEvent = null;
 const texts = new Set();
 const families = new Set();
 const eventTypes = new Set();
+const dotDiameter = 12;
+const spacing = 15;
+const step = 5;
+
 const eventTypeColors = {};
 
 document.getElementById('toggle-legend').addEventListener('click', () => {
@@ -23,18 +27,15 @@ document.getElementById('toggle-sidebar').addEventListener('click', () => {
     arrow.classList.toggle('collapsed');
 });
 
-async function loadEvents() {
+async function loadInitialEvents() {
     try {
-        // Fetch and process initial events
         const historicalEvents = await fetch('historical_events.json').then(response => response.json());
         const manuscriptEvents = await fetch('manuscripts.json').then(response => response.json());
         const uncialsEvents = await fetch('uncials.json').then(response => response.json());
         const churchFathersEvents = await fetch('church_fathers.json').then(response => response.json());
 
-        // Process initial events
         processEvents(historicalEvents, manuscriptEvents, uncialsEvents, churchFathersEvents);
 
-        // Initial updates
         generateColorsForEventTypes();
         updateEvents();
         initializeFilters();
@@ -42,34 +43,28 @@ async function loadEvents() {
         populateFamilyList();
         generateLegend();
     } catch (error) {
-        console.error('Error loading events:', error);
+        console.error('Error loading initial events:', error);
     }
 }
 
-// Load more events on clicking the "Load More" button
-document.getElementById('load-more-all').addEventListener('click', async () => {
+async function loadAdditionalEvents() {
     try {
         const lectionariesEvents = await fetch('lectionaries.json').then(response => response.json());
         const minusculesEvents = await fetch('minuscules.json').then(response => response.json());
 
-        // Process additional events
         processEvents(lectionariesEvents, minusculesEvents);
 
-        // Generate colors for any new event types that were loaded later
         generateColorsForEventTypes();
-
-        // Update the timeline with new events and colors
         updateEvents();
-        populateTextList(); // Repopulate text list
-        populateFamilyList(); // Repopulate family list
-        generateLegend(); // Refresh legend to include new event types with colors
-
-        // Hide the button after loading if desired
-        document.getElementById('load-more-all').style.display = 'none';
+        populateTextList();
+        populateFamilyList();
+        generateLegend();
     } catch (error) {
-        console.error('Error loading more events:', error);
+        console.error('Error loading additional events:', error);
     }
-});
+}
+
+document.getElementById('load-more-event-types').addEventListener('click', loadAdditionalEvents);
 
 function processEvents(...eventGroups) {
     eventGroups.forEach(events => {
@@ -120,7 +115,6 @@ function generateColorsForEventTypes() {
         }
     });
 
-    // Update colors for existing events
     const events = document.querySelectorAll('.event');
     events.forEach(event => {
         const eventType = event.getAttribute('data-event-type');
@@ -182,7 +176,7 @@ function addEventToTimeline(event) {
     newEvent.setAttribute('data-event-type', event.eventType);
 
     let newLeft = (event.percentage * timeline.offsetWidth) / 100;
-    let newTop = parseFloat(event.y); // Get y coordinate directly from the JSON
+    let newTop = parseFloat(event.y);
 
     newEvent.style.left = `${newLeft}px`;
     newEvent.style.top = `${newTop}px`;
@@ -190,7 +184,6 @@ function addEventToTimeline(event) {
 
     timeline.appendChild(newEvent);
 
-    // Ensure year labels are always visible
     document.querySelectorAll('.year-label').forEach(label => {
         timeline.appendChild(label);
     });
@@ -303,7 +296,7 @@ function generateLegend() {
         const checkbox = document.createElement('input');
         checkbox.type = 'checkbox';
         checkbox.className = 'legend-checkbox';
-        checkbox.checked = true;
+        checkbox.checked = !(eventType === 'lectionary' || eventType === 'Minuscule');
         checkbox.addEventListener('change', (e) => {
             toggleEventsByType(eventType, e.target.checked);
         });
@@ -402,5 +395,5 @@ new ResizeObserver(() => {
 }).observe(timelineContainer);
 
 document.addEventListener('DOMContentLoaded', function() {
-    loadEvents();
+    loadInitialEvents();
 });

--- a/scripts.js
+++ b/scripts.js
@@ -54,7 +54,7 @@ async function loadEvents() {
     }
 }
 
-// New function to load deferred event types when "Load More" is clicked
+// Function to load deferred events when "Load More" is clicked
 async function loadDeferredEvents(eventType) {
     try {
         let eventsToLoad;

--- a/scripts.js
+++ b/scripts.js
@@ -29,13 +29,16 @@ document.getElementById('toggle-sidebar').addEventListener('click', () => {
 
 async function loadInitialEvents() {
     try {
+        // Fetch and process initial events
         const historicalEvents = await fetch('historical_events.json').then(response => response.json());
         const manuscriptEvents = await fetch('manuscripts.json').then(response => response.json());
         const uncialsEvents = await fetch('uncials.json').then(response => response.json());
         const churchFathersEvents = await fetch('church_fathers.json').then(response => response.json());
 
+        // Process initial events
         processEvents(historicalEvents, manuscriptEvents, uncialsEvents, churchFathersEvents);
 
+        // Initial updates
         generateColorsForEventTypes();
         updateEvents();
         initializeFilters();
@@ -47,24 +50,25 @@ async function loadInitialEvents() {
     }
 }
 
-async function loadAdditionalEvents() {
+async function loadMoreEvents() {
     try {
+        // Fetch additional events
         const lectionariesEvents = await fetch('lectionaries.json').then(response => response.json());
         const minusculesEvents = await fetch('minuscules.json').then(response => response.json());
 
+        // Process additional events
         processEvents(lectionariesEvents, minusculesEvents);
 
+        // Update the timeline with new events and colors
         generateColorsForEventTypes();
         updateEvents();
-        populateTextList();
-        populateFamilyList();
-        generateLegend();
+        populateTextList(); // Repopulate text list
+        populateFamilyList(); // Repopulate family list
+        generateLegend(); // Refresh legend to include new event types with colors
     } catch (error) {
-        console.error('Error loading additional events:', error);
+        console.error('Error loading more events:', error);
     }
 }
-
-document.getElementById('load-more-event-types').addEventListener('click', loadAdditionalEvents);
 
 function processEvents(...eventGroups) {
     eventGroups.forEach(events => {
@@ -115,6 +119,7 @@ function generateColorsForEventTypes() {
         }
     });
 
+    // Update colors for existing events
     const events = document.querySelectorAll('.event');
     events.forEach(event => {
         const eventType = event.getAttribute('data-event-type');
@@ -176,7 +181,7 @@ function addEventToTimeline(event) {
     newEvent.setAttribute('data-event-type', event.eventType);
 
     let newLeft = (event.percentage * timeline.offsetWidth) / 100;
-    let newTop = parseFloat(event.y);
+    let newTop = parseFloat(event.y); // Get y coordinate directly from the JSON
 
     newEvent.style.left = `${newLeft}px`;
     newEvent.style.top = `${newTop}px`;
@@ -184,6 +189,7 @@ function addEventToTimeline(event) {
 
     timeline.appendChild(newEvent);
 
+    // Ensure year labels are always visible
     document.querySelectorAll('.year-label').forEach(label => {
         timeline.appendChild(label);
     });
@@ -270,18 +276,6 @@ function initializeFilters() {
     });
 }
 
-function generateColorsForEventTypes() {
-    eventTypes.forEach(eventType => {
-        if (!eventTypeColors[eventType]) {
-            eventTypeColors[eventType] = `#${Math.floor(Math.random() * 16777215).toString(16)}`;
-        }
-    });
-}
-
-function getColorForEventType(eventType) {
-    return eventTypeColors[eventType];
-}
-
 function generateLegend() {
     legendContainer.innerHTML = '';
 
@@ -296,6 +290,7 @@ function generateLegend() {
         const checkbox = document.createElement('input');
         checkbox.type = 'checkbox';
         checkbox.className = 'legend-checkbox';
+        // Uncheck the uncial and minuscule filters by default
         checkbox.checked = !(eventType === 'lectionary' || eventType === 'Minuscule');
         checkbox.addEventListener('change', (e) => {
             toggleEventsByType(eventType, e.target.checked);
@@ -309,7 +304,7 @@ function generateLegend() {
         questionMark.textContent = '?';
         const tooltip = document.createElement('span');
         tooltip.className = 'tooltip';
-        tooltip.textContent = `Filter events by ${eventType} type!`;
+        tooltip.textContent = `Filter events by ${eventType} type`;
         questionMark.appendChild(tooltip);
         legendItem.appendChild(checkbox);
         legendItem.appendChild(legendColor);
@@ -396,4 +391,6 @@ new ResizeObserver(() => {
 
 document.addEventListener('DOMContentLoaded', function() {
     loadInitialEvents();
+    // Add an event listener to load more events when the button is clicked
+    document.getElementById('load-more-event-types').addEventListener('click', loadMoreEvents);
 });

--- a/scripts.js
+++ b/scripts.js
@@ -280,6 +280,7 @@ function generateLegend() {
         legendItem.appendChild(label);
         legendItem.appendChild(questionMark);
 
+        // Add Load More button for deferred event types
         if (eventType === 'minuscules' || eventType === 'lectionaries') {
             const loadMoreButton = document.createElement('button');
             loadMoreButton.textContent = 'Load More';

--- a/styles.css
+++ b/styles.css
@@ -335,3 +335,24 @@ header {
 ::-webkit-scrollbar-thumb:hover {
     background: #777;
 }
+
+.load-more-btn {
+    margin-left: 10px;
+    background-color: #3498db;
+    color: #fff;
+    border: none;
+    padding: 5px 10px;
+    cursor: pointer;
+    border-radius: 5px;
+    transition: background-color 0.3s;
+}
+
+.load-more-btn:hover {
+    background-color: #2980b9;
+}
+
+.load-more-btn:disabled {
+    background-color: #aaa;
+    cursor: not-allowed;
+}
+


### PR DESCRIPTION
The filters for texts and manuscript families don't work anymore. there are also superfluous "load more" buttons beside a couple of event types, which flash and disappear quickly and which are not used, which could be removed.
there should probably be a progress bar or a "loading" icon while the lectionaires and minuscules are loading, cause it takes a heck of a long time. or maybe we should load one of them first, then the other?